### PR TITLE
Set min_compute_nodes

### DIFF
--- a/elements/single-hypervisor.conf.j2
+++ b/elements/single-hypervisor.conf.j2
@@ -1,6 +1,9 @@
 # Include this if your cloud only has a single hypervisor.
 # It should be included after the vm element.
 
+[compute]
+min_compute_nodes = 1
+
 [compute-feature-enabled]
 cold_migration = false
 live_migration = false

--- a/elements/vm.conf.j2
+++ b/elements/vm.conf.j2
@@ -1,5 +1,10 @@
 # Tempest configuration for virtual machines
 
+[compute]
+# Needed for live migration tests not to be skipped
+# e.g tempest.api.compute.admin.test_live_migration.LiveMigrationTest.test_live_block_migration
+min_compute_nodes = 2
+
 [compute-feature-enabled]
 resize = true
 # Rally sets live_migration to false


### PR DESCRIPTION
This should prevent multinode tests from being skipped, e.g:

tempest.api.compute.admin.test_live_migration.LiveMigrationTest.test_live_block_migration

Less than 2 compute nodes, skipping migration test.