### PR TITLE
Add supported microversion range for volumes

### DIFF
--- a/elements/openstack-version-queens.conf.j2
+++ b/elements/openstack-version-queens.conf.j2
@@ -5,3 +5,8 @@
 # See https://docs.openstack.org/nova/latest/reference/api-microversion-history.html
 min_microversion = 2.1
 max_microversion = 2.60
+
+[volume]
+# https://docs.openstack.org/cinder/train/contributor/api_microversion_history.html#maximum-in-queens
+min_microversion = 3.0
+max_microversion = 3.50

--- a/elements/openstack-version-rocky.conf.j2
+++ b/elements/openstack-version-rocky.conf.j2
@@ -5,3 +5,8 @@
 # See https://docs.openstack.org/nova/latest/reference/api-microversion-history.html
 min_microversion = 2.1
 max_microversion = 2.65
+
+[volume]
+# https://docs.openstack.org/cinder/train/contributor/api_microversion_history.html#maximum-in-rocky
+min_microversion = 3.0
+max_microversion = 3.55

--- a/elements/openstack-version-stein.conf.j2
+++ b/elements/openstack-version-stein.conf.j2
@@ -5,3 +5,8 @@
 # See https://docs.openstack.org/nova/latest/reference/api-microversion-history.html
 min_microversion = 2.1
 max_microversion = 2.72
+
+[volume]
+# https://docs.openstack.org/cinder/train/contributor/api_microversion_history.html#maximum-in-stein-and-train
+min_microversion = 3.0
+max_microversion = 3.59

--- a/elements/openstack-version-train.conf.j2
+++ b/elements/openstack-version-train.conf.j2
@@ -5,3 +5,8 @@
 # See https://docs.openstack.org/nova/latest/reference/api-microversion-history.html
 min_microversion = 2.1
 max_microversion = 2.79
+
+[volume]
+# https://docs.openstack.org/cinder/train/contributor/api_microversion_history.html#maximum-in-stein-and-train
+min_microversion = 3.0
+max_microversion = 3.59


### PR DESCRIPTION
Without this certain tests will refuse to run, e.g:

tempest.api.volume.test_volumes_get.VolumesSummaryTest.test_show_volume_summary
The microversion range[3.12 - latest] of this test is out of the configuration range[None - None].