### PR TITLE
Fix Ansible syntax

### DIFF
--- a/elements/vm.conf.j2
+++ b/elements/vm.conf.j2
@@ -11,4 +11,4 @@ resize = true
 live_migration = true
 # Rally expects shared storage by default. However we often configure virtual
 # machines to use local storage for their root disks.
-block_migration_for_live_migration = {{ block_migration_for_live_migration | bool | default(true) }}
+block_migration_for_live_migration = {{ block_migration_for_live_migration | default(true) | bool }}

--- a/elements/volume.conf.j2
+++ b/elements/volume.conf.j2
@@ -1,2 +1,2 @@
 [volume-feature-enabled]
-backup = {{ volume_backup | bool | default(true) }}
+backup = {{ volume_backup | default(true) | bool }}


### PR DESCRIPTION
Ansible fails if `block_migration_for_live_migration` or `volume_backup` are undefined.