### PR TITLE
Enable volume-backed live migration for virtual machines

### DIFF
--- a/elements/vm.conf.j2
+++ b/elements/vm.conf.j2
@@ -12,3 +12,4 @@ live_migration = true
 # Rally expects shared storage by default. However we often configure virtual
 # machines to use local storage for their root disks.
 block_migration_for_live_migration = {{ block_migration_for_live_migration | default(true) | bool }}
+volume_backed_live_migration = {{ volume_backed_live_migration | default(true) | bool }}


### PR DESCRIPTION
This requires Cinder to be available.